### PR TITLE
fix: add fallback ContextTypes

### DIFF
--- a/sfmark3.py
+++ b/sfmark3.py
@@ -503,7 +503,14 @@ try:
     )
 except ModuleNotFoundError:  # pragma: no cover - 테스트 환경용 더미
     Update = InlineKeyboardButton = InlineKeyboardMarkup = ForceReply = object  # type: ignore
-    Application = CallbackQueryHandler = CommandHandler = ContextTypes = MessageHandler = object  # type: ignore
+    Application = CallbackQueryHandler = CommandHandler = MessageHandler = object  # type: ignore
+
+    class DummyContextTypes:
+        """Fallback context holder when telegram.ext is unavailable."""
+
+        DEFAULT_TYPE = object
+
+    ContextTypes = DummyContextTypes  # type: ignore
 
     class filters:  # type: ignore
         TEXT = COMMAND = None


### PR DESCRIPTION
## Summary
- avoid AttributeError when telegram.ext is unavailable by providing DummyContextTypes with DEFAULT_TYPE

## Testing
- `python -m py_compile sfmark3.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd01216db4832991c75f97dd100ffa