### PR TITLE
Add systemd service for automatic startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,14 @@ Photos for the background slideshow are loaded from `/root/rsf/photo`.
 - **Telegram bot**: default mode is polling and only requires outbound internet access. To use webhook mode,
   set `telegram.mode` to `"webhook"` and provide a publicly reachable HTTPS URL in `telegram.webhook_base`; ensure this
   URL forwards requests to the server's `:5320` port.
+
+## Autostart with systemd
+To run the application on boot using systemd:
+
+```bash
+sudo cp rsf.service /etc/systemd/system/
+sudo systemctl enable rsf.service
+sudo systemctl start rsf.service
+```
+
+This service runs `run.sh` from `/root/rsf` and restarts on failure.

--- a/rsf.service
+++ b/rsf.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Smart Frame service
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/root/rsf
+ExecStart=/root/rsf/run.sh
+Restart=on-failure
+RestartSec=5
+User=root
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add systemd unit file to run `run.sh` on boot
- document autostart setup in README

## Testing
- `bash -n run.sh`
- `python -m py_compile sfmark3.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd54c2003083299b1de6d68da50913