### PR TITLE
Add web settings page with config and photo upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ source .venv/bin/activate
 python sfmark3.py
 ```
 The server listens on port `5320` and serves the board at `http://<host>:5320/board`.
+Configuration and photo management is available at `http://<host>:5320/setting`.
 Photos for the background slideshow are loaded from `/root/rsf/photo`.
 
 ## Network configuration


### PR DESCRIPTION
## Summary
- add `/setting` page for entering configuration values and uploading photos
- expose new API endpoints for reading/updating config and saving to embedded block
- support photo uploads from mobile or desktop and list current images

## Testing
- `python -m py_compile sfmark3.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdafdd51b483299e12f6e0ce3c7763